### PR TITLE
Fixed Issue #2 (https://github.com/jdm/trainingmontage/issues/2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@
     <h1>Let's get started</h1>
     <p>What operating system do you use?</p>
     <p><span class="button" next="win">Windows</span></p>
-    <p><span class="button" next="linux/osx">OS X (Apple)</span></p>
-    <p><span class="button" next="linux/osx">Linux</span></p>
+    <p><span class="button" next="linuxosx">OS X (Apple)</span></p>
+    <p><span class="button" next="linuxosx">Linux</span></p>
     </p>
   </div>
 
@@ -33,7 +33,7 @@
     <p><span class="button" next="source">I'm finished!</span></p>
   </div>
 
-  <div id="linux/osx" class="step">
+  <div id="linuxosx" class="step">
     <h1>Great! Time to set up your development environment!</h1>
     <p>If you run this script in your terminal, the packages required to build Firefox  will be installed.</p>
     <p><code>wget --no-check-certificate https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py && python bootstrap.py</code></p>


### PR DESCRIPTION
The slash in "linux/osx" on the next button and div id broke the linux
and mac info so I renamed them without a slash.
